### PR TITLE
店舗情報の重複修正

### DIFF
--- a/app/controllers/static_pages_Controller.rb
+++ b/app/controllers/static_pages_Controller.rb
@@ -7,11 +7,16 @@ class StaticPagesController < ApplicationController
   end
 
   def create_store
-    store = Store.new(store_params)
-    if store.save
-      render json: { message: "#{store.name}をStoresテーブルに保存しました" }, status: :created
+    store = Store.find_or_initialize_by(place_id: store_params[:place_id])
+    if store.new_record?
+      store.assign_attributes(store_params)
+      if store.save
+        render json: { message: "#{store.name}をStoresテーブルに保存しました" }, status: :created
+      else
+        render json: { errors: store.errors.full_messages }, status: :unprocessable_entity
+      end
     else
-      render json: { errors: store.errors.full_messages }, status: :unprocessable_entity
+      render json: { message: "#{store.name}は既に保存されています" }, status: :ok
     end
   end
 

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -173,11 +173,12 @@
         },
         body: JSON.stringify(storeData)
       })
-      .then(response => {
-        if (response.ok) {
-          console.log(`${storeData.store.name}をStoresテーブルに保存しました`);
+      .then(response => response.json())
+      .then(data => {
+        if (data.errors) {
+          console.log("保存に失敗しました:", data.errors);
         } else {
-          console.error("保存に失敗しました");
+          console.error(data.message);
         }
       })
       .catch(error => {

--- a/db/migrate/20250316123422_add_unique_index_to_stores_place_id.rb
+++ b/db/migrate/20250316123422_add_unique_index_to_stores_place_id.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToStoresPlaceId < ActiveRecord::Migration[7.2]
+  def change
+    add_index :stores, :place_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_28_121635) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_16_123422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_28_121635) do
     t.string "place_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["place_id"], name: "index_stores_on_place_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
# 実施内容
Storesテーブルに二重で保存されるエラーを修正しました。

# 実装内容
① t.index ["place_id"], name: "index_stores_on_place_id", unique: trueを追加しました。

② static_pages_controllerに新しいレコードか確認する処理を追加
